### PR TITLE
Modificación de borrar con restricciones de integridad

### DIFF
--- a/src/Controller/BrandsController.php
+++ b/src/Controller/BrandsController.php
@@ -83,14 +83,16 @@ class BrandsController extends AppController
      */
     public function delete($id = null)
     {
+        
         $this->request->allowMethod(['post', 'delete']);
         $brand = $this->Brands->get($id);
-        if ($this->Brands->delete($brand)) {
-            $this->Flash->success(__('La marca se ha eliminado exitosamente'));
-        } else {
-            $this->Flash->error(__('La marca no se pudo eliminar. Por favor, inténtelo de nuevo'));
+        try{
+            $this->Brands->delete($brand); 
+             $this->Flash->success(__('La marca se ha eliminado exitosamente'));
+        } catch (\PDOException $e) {
+     $this->Flash->error(__('La marca no se pudo eliminar. Puede deberse a que tiene modelos asociados a ella'));
         }
-
+        
         return $this->redirect(['action' => 'index']);
     }
 }

--- a/src/Controller/TypesController.php
+++ b/src/Controller/TypesController.php
@@ -98,10 +98,11 @@ class TypesController extends AppController
     {
         $this->request->allowMethod(['post', 'delete']);
         $type = $this->Types->get($id);
-        if ($this->Types->delete($type)) {
-            $this->Flash->success(__('El tipo de activo fue borrado exitosamente.'));
-        } else {
-            $this->Flash->error(__('El tipo de activo no se pudo borrar, por favor intente nuevamente.'));
+        try{
+            $this->Types->delete($type); 
+             $this->Flash->success(__('El tipo de activo se ha eliminado exitosamente'));
+        } catch (\PDOException $e) {
+     $this->Flash->error(__('El tipo de activo no se pudo eliminar. Puede deberse a que tiene activos asociados'));
         }
 
         return $this->redirect(['action' => 'index']);


### PR DESCRIPTION
Se agregaron try catch en los eliminar de Types y Brands para los que tienen restricciones de integridad, para no mostrar mensaje de error de cake

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.